### PR TITLE
Add OpenSingleDirectory and an example with all dialogs

### DIFF
--- a/examples/tour.rs
+++ b/examples/tour.rs
@@ -1,0 +1,48 @@
+use native_dialog::*;
+
+fn echo<T: std::fmt::Debug>(name: &str, value: &T) {
+    let dialog = MessageAlert {
+        title: "Result",
+        text: &format!("{}: {:?}", &name, &value),
+        typ: MessageType::Info,
+    };
+    dialog.show().unwrap();
+}
+
+fn main() {
+    let dialog = MessageConfirm {
+        title: "Tour",
+        text: "Let's begin the tour!",
+        typ: MessageType::Info,
+    };
+    let result = dialog.show().unwrap();
+    if !result {
+        return;
+    }
+    echo("MessageConfirm", &result);
+
+    let dialog = OpenSingleFile {
+        dir: None,
+        filter: None,
+    };
+    let result = dialog.show().unwrap();
+    echo("OpenSingleFile", &result);
+
+    let dialog = OpenMultipleFile {
+        dir: None,
+        filter: None,
+    };
+    let result = dialog.show().unwrap();
+    echo("OpenMultipleFile", &result);
+
+    let dialog = OpenSingleDirectory { dir: None };
+    let result = dialog.show().unwrap();
+    echo("OpenSingleDirectory", &result);
+
+    let dialog = MessageAlert {
+        title: "End",
+        text: "That's the end!",
+        typ: MessageType::Info,
+    };
+    dialog.show().unwrap();
+}

--- a/src/file.rs
+++ b/src/file.rs
@@ -8,6 +8,10 @@ pub struct OpenMultipleFile<'a> {
     pub filter: Option<&'a [&'a str]>,
 }
 
+pub struct OpenSingleDirectory<'a> {
+    pub dir: Option<&'a str>,
+}
+
 pub struct SaveFile<'a> {
     pub dir: Option<&'a str>,
     pub name: &'a str,

--- a/src/impl/mod.rs
+++ b/src/impl/mod.rs
@@ -6,3 +6,9 @@ pub(crate) mod gnu;
 
 #[cfg(target_os = "windows")]
 pub(crate) mod win;
+
+#[derive(PartialEq)]
+pub(crate) enum OpenDialogTarget {
+    File,
+    Directory,
+}


### PR DESCRIPTION
I was only able to test this on Windows and Linux + Zenity, but I followed the documentation I could find for kdialog and Mac. Would you be able to test this out on those systems?

I added the new example since it gives you a quick way to try out everything at once. I found it handy for testing.

Great crate, by the way! I was happy to find something without any special build dependencies.