### PR TITLE
Set documentation link to docs.rs instead of the README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["balthild <ibalthild@gmail.com>"]
 edition = "2018"
 description = "A library to display dialogs. Supports GNU/Linux, macOS and Windows."
 license = "MIT"
-documentation = "https://github.com/balthild/native-dialog-rs/blob/master/README.md"
+documentation = "https://docs.rs/native-dialog-rs"
 repository = "https://github.com/balthild/native-dialog-rs"
 
 [dependencies]


### PR DESCRIPTION
This is what I've observed as the "normal" thing to do, and it's also
what I've come to expect.