### PR TITLE
Unbreak on BSDs and Solaris

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ wfd = "0.1.4"
 winapi = { version = "0.3", features = ["winuser"] }
 once_cell = { version = "1.4.0", optional = true }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
 which = "4.0.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/impl/mod.rs
+++ b/src/impl/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "macos")]
 pub(crate) mod mac;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
 pub(crate) mod gnu;
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
`kdialog` and `zenity` do exist on DragonFly/FreeBSD/NetBSD/OpenBSD and probably Solaris-like systems. Found via veloren 0.7.0 -> 0.8.0 update.