### PR TITLE
Add "progress dialog" API & implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ raw-window-handle = "0.3.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 wfd = "0.1.7"
-winapi = { version = "0.3", features = ["winuser"] }
+winapi = { version = "0.3", features = ["winuser", "windef"] }
 once_cell = { version = "1.4.0", optional = true }
 
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -1,0 +1,31 @@
+use std::thread::sleep;
+use std::time::Duration;
+
+use native_dialog::{Error, ProgressDialog};
+
+fn main() -> Result<(), Error> {
+    let progress = ProgressDialog::new()
+        .set_title("Progress Example")
+        .set_text("Doing complicated things...")
+        .show()?;
+
+    let mut handle = progress.borrow_mut();
+    handle.set_progress(20.0)?;
+
+    sleep(Duration::from_secs(3));
+    if handle.check_cancelled()? {
+        eprintln!("Cancelled!");
+        return Ok(())
+    }
+
+    handle.set_progress(80.0)?;
+    handle.set_text("Almost there...")?;
+
+    sleep(Duration::from_secs(2));
+    handle.set_progress(100.0)?;
+
+    sleep(Duration::from_secs(1));
+    handle.close()?;
+
+    Ok(())
+}

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Error> {
     sleep(Duration::from_secs(3));
     if handle.check_cancelled()? {
         eprintln!("Cancelled!");
-        return Ok(())
+        return Ok(());
     }
 
     handle.set_progress(80.0)?;

--- a/src/dialog/mod.rs
+++ b/src/dialog/mod.rs
@@ -1,3 +1,7 @@
+pub use file::*;
+pub use message::*;
+pub use progress::*;
+
 pub trait Dialog {
     type Output;
 }
@@ -7,7 +11,5 @@ pub trait DialogImpl: Dialog {
 }
 
 mod file;
-pub use file::*;
-
 mod message;
-pub use message::*;
+mod progress;

--- a/src/dialog/progress.rs
+++ b/src/dialog/progress.rs
@@ -1,0 +1,9 @@
+use std::cell::RefCell;
+
+use crate::{ProgressDialog, ProgressHandle};
+
+use super::Dialog;
+
+impl Dialog for ProgressDialog<'_> {
+    type Output = Box<RefCell<dyn ProgressHandle>>;
+}

--- a/src/dialog_impl/gnu/message.rs
+++ b/src/dialog_impl/gnu/message.rs
@@ -1,7 +1,9 @@
-use super::{should_use, UseCommand};
-use crate::dialog::{DialogImpl, MessageAlert, MessageConfirm};
-use crate::{Error, MessageType, Result};
 use std::process::Command;
+
+use crate::{Error, MessageType, Result};
+use crate::dialog::{DialogImpl, MessageAlert, MessageConfirm};
+
+use super::{escape_pango_entities, should_use, UseCommand};
 
 impl DialogImpl for MessageAlert<'_> {
     fn show(&mut self) -> Result<Self::Output> {
@@ -39,17 +41,6 @@ impl DialogImpl for MessageConfirm<'_> {
             UseCommand::Zenity(cmd) => call_zenity(cmd, params),
         }
     }
-}
-
-/// GMarkup flavoured XML has defined only 5 entities and doesn't support user-defined entities.
-/// Should we reimplement the complete `g_markup_escape_text` function?
-/// See https://gitlab.gnome.org/GNOME/glib/-/blob/353942c6/glib/gmarkup.c#L2296
-fn escape_pango_entities(text: &str) -> String {
-    text.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
 }
 
 struct Params<'a> {

--- a/src/dialog_impl/gnu/mod.rs
+++ b/src/dialog_impl/gnu/mod.rs
@@ -1,13 +1,26 @@
-use crate::Error;
 use std::env;
 use std::process::Command;
 
+use crate::Error;
+
 mod file;
 mod message;
+mod progress;
 
 enum UseCommand {
     KDialog(Command),
     Zenity(Command),
+}
+
+/// GMarkup flavoured XML has defined only 5 entities and doesn't support user-defined entities.
+/// Should we reimplement the complete `g_markup_escape_text` function?
+/// See https://gitlab.gnome.org/GNOME/glib/-/blob/353942c6/glib/gmarkup.c#L2296
+fn escape_pango_entities(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
 }
 
 fn should_use() -> Option<UseCommand> {

--- a/src/dialog_impl/gnu/progress.rs
+++ b/src/dialog_impl/gnu/progress.rs
@@ -13,7 +13,7 @@ impl DialogImpl for ProgressDialog<'_> {
 
         match command {
             UseCommand::KDialog(c) => call_kdialog(c, self),
-            UseCommand::Zenity(c) => call_zenity(c, self)
+            UseCommand::Zenity(c) => call_zenity(c, self),
         }
     }
 }
@@ -77,7 +77,10 @@ impl ProgressHandle for KdialogProgressHandle {
     }
 }
 
-fn call_kdialog(mut command: Command, settings: &ProgressDialog) -> Result<Box<RefCell<dyn ProgressHandle>>> {
+fn call_kdialog(
+    mut command: Command,
+    settings: &ProgressDialog,
+) -> Result<Box<RefCell<dyn ProgressHandle>>> {
     command.arg("--progressbar");
     command.arg(settings.text);
     command.arg("100");
@@ -101,7 +104,7 @@ impl ZenityProgressHandle {
     fn new(mut child: Child) -> Self {
         ZenityProgressHandle {
             stdin: child.stdin.take().unwrap(),
-            child
+            child,
         }
     }
 }
@@ -109,7 +112,7 @@ impl ZenityProgressHandle {
 impl ProgressHandle for ZenityProgressHandle {
     fn set_progress(&mut self, percent: f32) -> Result<()> {
         if percent < 0.0 || percent > 100.0 {
-            return Err(Error::InvalidPercentage(percent))
+            return Err(Error::InvalidPercentage(percent));
         }
 
         self.stdin.write(format!("{}\n", percent).as_bytes())?;
@@ -122,12 +125,13 @@ impl ProgressHandle for ZenityProgressHandle {
     }
 
     fn check_cancelled(&mut self) -> Result<bool> {
-        self.child.try_wait().map(|opt| {
-            match opt {
+        self.child
+            .try_wait()
+            .map(|opt| match opt {
                 None => false,
-                Some(status) => !status.success()
-            }
-        }).map_err(|e| Error::IoFailure(e))
+                Some(status) => !status.success(),
+            })
+            .map_err(|e| Error::IoFailure(e))
     }
 
     fn close(&mut self) -> Result<()> {
@@ -145,7 +149,10 @@ impl ProgressHandle for ZenityProgressHandle {
     }
 }
 
-fn call_zenity(mut command: Command, settings: &ProgressDialog) -> Result<Box<RefCell<dyn ProgressHandle>>> {
+fn call_zenity(
+    mut command: Command,
+    settings: &ProgressDialog,
+) -> Result<Box<RefCell<dyn ProgressHandle>>> {
     command.arg("--progress");
 
     command.arg("--title");

--- a/src/dialog_impl/gnu/progress.rs
+++ b/src/dialog_impl/gnu/progress.rs
@@ -1,0 +1,163 @@
+use std::cell::RefCell;
+use std::io::{ErrorKind, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
+
+use crate::{Error, ProgressDialog, ProgressHandle, Result};
+use crate::dialog::DialogImpl;
+
+use super::{escape_pango_entities, should_use, UseCommand};
+
+impl DialogImpl for ProgressDialog<'_> {
+    fn show(&mut self) -> Result<Self::Output> {
+        let command = should_use().ok_or(Error::NoImplementation)?;
+
+        match command {
+            UseCommand::KDialog(c) => call_kdialog(c, self),
+            UseCommand::Zenity(c) => call_zenity(c, self)
+        }
+    }
+}
+
+struct KdialogProgressHandle {
+    dbus_ref: String,
+}
+
+impl ProgressHandle for KdialogProgressHandle {
+    fn set_progress(&mut self, percent: f32) -> Result<()> {
+        let status = Command::new("qdbus")
+            .arg(&self.dbus_ref)
+            .arg("Set")
+            .arg("\"\"")
+            .arg("value")
+            .arg(format!("{}", percent as i32))
+            .status()?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            Err(Error::ImplementationError("Failed to run qdbus".into()))
+        }
+    }
+
+    fn set_text(&mut self, text: &str) -> Result<()> {
+        let status = Command::new("qdbus")
+            .arg(&self.dbus_ref)
+            .arg("setLabelText")
+            .arg(text)
+            .status()?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            Err(Error::ImplementationError("Failed to run qdbus".into()))
+        }
+    }
+
+    fn check_cancelled(&mut self) -> Result<bool> {
+        let output = Command::new("qdbus")
+            .arg(&self.dbus_ref)
+            .arg("wasCancelled")
+            .output()?;
+
+        let text = String::from_utf8(output.stdout)?;
+        Ok(text == "true")
+    }
+
+    fn close(&mut self) -> Result<()> {
+        let status = Command::new("qdbus")
+            .arg(&self.dbus_ref)
+            .arg("close")
+            .status()?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            Err(Error::ImplementationError("Failed to run qdbus".into()))
+        }
+    }
+}
+
+fn call_kdialog(mut command: Command, settings: &ProgressDialog) -> Result<Box<RefCell<dyn ProgressHandle>>> {
+    command.arg("--progressbar");
+    command.arg(settings.text);
+    command.arg("100");
+
+    command.arg("--title");
+    command.arg(settings.title);
+
+    let output = command.output()?;
+    let dbus_ref = String::from_utf8(output.stdout)?;
+    let handle = KdialogProgressHandle { dbus_ref };
+
+    Ok(Box::new(RefCell::new(handle)))
+}
+
+struct ZenityProgressHandle {
+    child: Child,
+    stdin: ChildStdin,
+}
+
+impl ZenityProgressHandle {
+    fn new(mut child: Child) -> Self {
+        ZenityProgressHandle {
+            stdin: child.stdin.take().unwrap(),
+            child
+        }
+    }
+}
+
+impl ProgressHandle for ZenityProgressHandle {
+    fn set_progress(&mut self, percent: f32) -> Result<()> {
+        if percent < 0.0 || percent > 100.0 {
+            return Err(Error::InvalidPercentage(percent))
+        }
+
+        self.stdin.write(format!("{}\n", percent).as_bytes())?;
+        Ok(())
+    }
+
+    fn set_text(&mut self, text: &str) -> Result<()> {
+        self.stdin.write(format!("# {}\n", text).as_bytes())?;
+        Ok(())
+    }
+
+    fn check_cancelled(&mut self) -> Result<bool> {
+        self.child.try_wait().map(|opt| {
+            match opt {
+                None => false,
+                Some(status) => !status.success()
+            }
+        }).map_err(|e| Error::IoFailure(e))
+    }
+
+    fn close(&mut self) -> Result<()> {
+        match self.child.kill() {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                if err.kind() == ErrorKind::InvalidInput {
+                    // Process is already dead, ignore
+                    Ok(())
+                } else {
+                    Err(Error::IoFailure(err))
+                }
+            }
+        }
+    }
+}
+
+fn call_zenity(mut command: Command, settings: &ProgressDialog) -> Result<Box<RefCell<dyn ProgressHandle>>> {
+    command.arg("--progress");
+
+    command.arg("--title");
+    command.arg(settings.title);
+
+    command.arg("--text");
+    command.arg(escape_pango_entities(settings.text));
+
+    command.stdin(Stdio::piped());
+
+    let child = command.spawn()?;
+    let handle = ZenityProgressHandle::new(child);
+
+    Ok(Box::new(RefCell::new(handle)))
+}

--- a/src/dialog_impl/win/mod.rs
+++ b/src/dialog_impl/win/mod.rs
@@ -1,5 +1,6 @@
 mod file;
 mod message;
+mod progress;
 
 fn process_init() {
     use std::sync::Once;

--- a/src/dialog_impl/win/progress.rs
+++ b/src/dialog_impl/win/progress.rs
@@ -17,12 +17,8 @@ impl<'a> DialogImpl for ProgressDialog<'a> {
         use std::iter::once;
         use std::os::windows::ffi::OsStrExt;
         use std::ptr::null_mut;
-        use winapi::um::winuser::{
-            CreateWindowExW, WS_BORDER, WS_POPUP, WS_VISIBLE
-        };
-        use winapi::um::commctrl::{
-            PROGRESS_CLASS, PBM_SETRANGE, PBM_SETSTEP,
-        };
+        use winapi::um::commctrl::{PBM_SETRANGE, PBM_SETSTEP, PROGRESS_CLASS};
+        use winapi::um::winuser::{CreateWindowExW, WS_BORDER, WS_POPUP, WS_VISIBLE};
 
         let class: Vec<u16> = OsStr::new(PROGRESS_CLASS)
             .encode_wide()
@@ -34,16 +30,22 @@ impl<'a> DialogImpl for ProgressDialog<'a> {
             .chain(once(0))
             .collect();
 
-        let handle = self.owner.map(|hndl| {
-            (hndlr as RawWindowHandle::Windows)
-        });
+        let handle = self.owner.map(|hndl| (hndlr as RawWindowHandle::Windows));
 
         let hwnd = super::with_visual_styles(|| unsafe {
             CreateWindowExW(
-                0,class.as_ptr(),caption.as_ptr(),
-                WS_BORDER | WS_POPUP | WS_VISIBLE, 0, 0, 300, 150,
-                handle.map(|h| h.hwnd).unwrap_or(null_mut()), null_mut(),
-                handle.map(|h| h.instance).unwrap_or(null_mut()), null_mut()
+                0,
+                class.as_ptr(),
+                caption.as_ptr(),
+                WS_BORDER | WS_POPUP | WS_VISIBLE,
+                0,
+                0,
+                300,
+                150,
+                handle.map(|h| h.hwnd).unwrap_or(null_mut()),
+                null_mut(),
+                handle.map(|h| h.instance).unwrap_or(null_mut()),
+                null_mut(),
             )
         });
 
@@ -67,7 +69,7 @@ impl ProgressHandle for WindowsProgressHandle {
         use winapi::um::commctrl::PBM_SETPOS;
 
         if percent < 0.0 || percent > 100.0 {
-            return Err(Error::InvalidPercentage(percent))
+            return Err(Error::InvalidPercentage(percent));
         }
 
         let pos = (percent * 10.0) as usize;
@@ -75,7 +77,7 @@ impl ProgressHandle for WindowsProgressHandle {
 
         match ret {
             0 => Err(std::io::Error::last_os_error().into()),
-            _ => Ok(())
+            _ => Ok(()),
         }
     }
 
@@ -86,7 +88,7 @@ impl ProgressHandle for WindowsProgressHandle {
     }
 
     fn check_cancelled(&mut self) -> Result<bool> {
-        use winapi::um::winuser::{PeekMessageW, MSG, LPMSG, WM_CLOSE, PM_REMOVE};
+        use winapi::um::winuser::{PeekMessageW, LPMSG, MSG, PM_REMOVE, WM_CLOSE};
 
         let msg: LPMSG = null_mut();
         let ret = unsafe { PeekMessageW(msg, self.hwnd, WM_CLOSE, WM_CLOSE, PM_REMOVE) };
@@ -108,7 +110,7 @@ impl ProgressHandle for WindowsProgressHandle {
         let ret = unsafe { DestroyWindow(self.hwnd) };
         match ret {
             0 => Err(std::io::Error::last_os_error().into()),
-            _ => Ok(())
+            _ => Ok(()),
         }
     }
 }

--- a/src/dialog_impl/win/progress.rs
+++ b/src/dialog_impl/win/progress.rs
@@ -1,0 +1,114 @@
+use std::cell::RefCell;
+use std::ptr::null_mut;
+
+use raw_window_handle::RawWindowHandle;
+use winapi::shared::windef::HWND;
+use winapi::um::winuser::SendMessageW;
+
+use crate::{Error, Result};
+use crate::{ProgressDialog, ProgressHandle};
+use crate::dialog::DialogImpl;
+
+impl<'a> DialogImpl for ProgressDialog<'a> {
+    fn show(&mut self) -> Result<Self::Output> {
+        super::process_init();
+
+        use std::ffi::OsStr;
+        use std::iter::once;
+        use std::os::windows::ffi::OsStrExt;
+        use std::ptr::null_mut;
+        use winapi::um::winuser::{
+            CreateWindowExW, WS_BORDER, WS_POPUP, WS_VISIBLE
+        };
+        use winapi::um::commctrl::{
+            PROGRESS_CLASS, PBM_SETRANGE, PBM_SETSTEP,
+        };
+
+        let class: Vec<u16> = OsStr::new(PROGRESS_CLASS)
+            .encode_wide()
+            .chain(once(0))
+            .collect();
+
+        let caption: Vec<u16> = OsStr::new(self.title)
+            .encode_wide()
+            .chain(once(0))
+            .collect();
+
+        let handle = self.owner.map(|hndl| {
+            (hndlr as RawWindowHandle::Windows)
+        });
+
+        let hwnd = super::with_visual_styles(|| unsafe {
+            CreateWindowExW(
+                0,class.as_ptr(),caption.as_ptr(),
+                WS_BORDER | WS_POPUP | WS_VISIBLE, 0, 0, 300, 150,
+                handle.map(|h| h.hwnd).unwrap_or(null_mut()), null_mut(),
+                handle.map(|h| h.instance).unwrap_or(null_mut()), null_mut()
+            )
+        });
+
+        unsafe {
+            // This is all integers so set upper limit to 1000 for smoothness
+            SendMessageW(hwnd, PBM_SETRANGE, 0, 1000);
+            SendMessageW(hwnd, PBM_SETSTEP, 1, 0);
+        };
+
+        let handle = WindowsProgressHandle { hwnd };
+        Ok(Box::new(RefCell::new(handle)))
+    }
+}
+
+struct WindowsProgressHandle {
+    hwnd: HWND,
+}
+
+impl ProgressHandle for WindowsProgressHandle {
+    fn set_progress(&mut self, percent: f32) -> Result<()> {
+        use winapi::um::commctrl::PBM_SETPOS;
+
+        if percent < 0.0 || percent > 100.0 {
+            return Err(Error::InvalidPercentage(percent))
+        }
+
+        let pos = (percent * 10.0) as usize;
+        let ret = unsafe { SendMessageW(self.hwnd, PBM_SETPOS, pos, 0) };
+
+        match ret {
+            0 => Err(std::io::Error::last_os_error().into()),
+            _ => Ok(())
+        }
+    }
+
+    fn set_text(&mut self, text: &str) -> Result<()> {
+        // Currently a noop because the progress window doesn't show text :(
+        // Maybe put it in the title bar?
+        Ok(())
+    }
+
+    fn check_cancelled(&mut self) -> Result<bool> {
+        use winapi::um::winuser::{PeekMessageW, MSG, LPMSG, WM_CLOSE, PM_REMOVE};
+
+        let msg: LPMSG = null_mut();
+        let ret = unsafe { PeekMessageW(msg, self.hwnd, WM_CLOSE, WM_CLOSE, PM_REMOVE) };
+
+        let res = match ret {
+            0 => false,
+            _ => {
+                self.close(); // clean up!!
+                true
+            }
+        };
+
+        Ok(res)
+    }
+
+    fn close(&mut self) -> Result<()> {
+        use winapi::um::winuser::DestroyWindow;
+
+        let ret = unsafe { DestroyWindow(self.hwnd) };
+        match ret {
+            0 => Err(std::io::Error::last_os_error().into()),
+            _ => Ok(())
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,6 @@ pub(crate) mod dialog;
 pub(crate) mod dialog_impl;
 pub(crate) mod util;
 
-mod message;
 mod file;
+mod message;
 mod progress;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,15 @@
 #[cfg(target_os = "macos")]
 #[macro_use]
 extern crate objc;
-
 #[cfg(target_os = "macos")]
 #[macro_use]
 extern crate objc_foundation;
 
 use thiserror::Error;
+
+pub use file::*;
+pub use message::*;
+pub use progress::*;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -24,6 +27,9 @@ pub enum Error {
 
     #[error("the implementation reports error")]
     ImplementationError(String),
+
+    #[error("Percentage must be between 0 and 100 inclusive, you passed {0}")]
+    InvalidPercentage(f32),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -33,7 +39,5 @@ pub(crate) mod dialog_impl;
 pub(crate) mod util;
 
 mod message;
-pub use message::*;
-
 mod file;
-pub use file::*;
+mod progress;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,73 @@
+use std::cell::RefCell;
+
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+
+use crate::dialog::DialogImpl;
+use crate::Result;
+
+pub struct ProgressDialog<'a> {
+    pub(crate) title: &'a str,
+    pub(crate) text: &'a str,
+    pub(crate) owner: Option<RawWindowHandle>,
+}
+
+pub trait ProgressHandle {
+    fn set_progress(&mut self, percent: f32) -> Result<()>;
+    fn set_text(&mut self, text: &str) -> Result<()>;
+    fn check_cancelled(&mut self) -> Result<bool>;
+    fn close(&mut self) -> Result<()>;
+}
+
+impl<'a> ProgressDialog<'a> {
+    pub fn new() -> Self {
+        ProgressDialog {
+            title: "",
+            text: "",
+            owner: None,
+        }
+    }
+
+    /// Set the title of the dialog.
+    pub fn set_title(mut self, title: &'a str) -> Self {
+        self.title = title;
+        self
+    }
+
+    /// Set the message text of the dialog.
+    pub fn set_text(mut self, text: &'a str) -> Self {
+        self.text = text;
+        self
+    }
+
+    /// Sets the owner of the dialog. On Unix and GNU/Linux, this is a no-op.
+    pub fn set_owner<W: HasRawWindowHandle>(mut self, window: &W) -> Self {
+        self.owner = Some(window.raw_window_handle());
+        self
+    }
+
+    /// Sets the owner of the dialog by raw handle. On Unix and GNU/Linux, this is a no-op.
+    ///pub(crate)
+    /// # Safety
+    ///
+    /// It's the caller's responsibility that ensuring the handle is valid.
+    pub unsafe fn set_owner_handle(mut self, handle: RawWindowHandle) -> Self {
+        self.owner = Some(handle);
+        self
+    }
+
+    /// Resets the owner of the dialog to nothing.
+    pub fn reset_owner(mut self) -> Self {
+        self.owner = None;
+        self
+    }
+
+    pub fn show(&mut self) -> Result<Box<RefCell<dyn ProgressHandle>>> {
+        DialogImpl::show(self)
+    }
+}
+
+impl Default for ProgressDialog<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
This PR implements progress dialogs which may be updated and queried by the application.

```rust
let progress = ProgressDialog::new()
    .set_title("Progress Example")
    .set_text("Doing complicated things...")
    .show()?;

let mut handle = progress.borrow_mut();
handle.set_progress(20.0)?;
```

Progress so far:

- [x] Linux compiles
- [x] Windows compiles
- [ ] Mac compiles
- [x] Linux with zenity tested & working well
- [ ] Linux with kdialog tested

Linux is tested & working, at least for Zenity.  
kdialog might need some extra bits (apparently `qdbus` can be named `qdbus-qt5` sometimes?)  
The Windows implementation *sort of* works; the progress bar doesn't seem to want to fit inside the window (I don't think it's supposed to be used like this!) and the text isn't displayed, so it needs a bunch more work.  
Mac is not implemented yet. I don't have access to a mac machine that I can develop on, and I have very little idea about the Cocoa API.

I welcome any assistance :)