### PR TITLE
Don't escape XML entities in KDialog

### DIFF
--- a/src/dialog_impl/gnu/message.rs
+++ b/src/dialog_impl/gnu/message.rs
@@ -52,6 +52,16 @@ fn escape_pango_entities(text: &str) -> String {
         .replace('\'', "&apos;")
 }
 
+/// See https://github.com/qt/qtbase/blob/2e2f1e2/src/gui/text/qtextdocument.cpp#L166
+fn convert_qt_text_document(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\n', "<br>")
+        .replace(&[' ', '\t'], "&nbsp;")
+}
+
 struct Params<'a> {
     title: &'a str,
     text: &'a str,
@@ -66,8 +76,7 @@ fn call_kdialog(mut command: Command, params: Params) -> Result<bool> {
         command.arg("--msgbox");
     }
 
-    // KDialog uses plain text rather than XML, thus entity escapes aren't needed.
-    command.arg(params.text);
+    command.arg(convert_qt_text_document(params.text));
 
     command.arg("--title");
     command.arg(params.title);

--- a/src/dialog_impl/gnu/message.rs
+++ b/src/dialog_impl/gnu/message.rs
@@ -66,7 +66,8 @@ fn call_kdialog(mut command: Command, params: Params) -> Result<bool> {
         command.arg("--msgbox");
     }
 
-    command.arg(escape_pango_entities(params.text));
+    // KDialog uses plain text rather than XML, thus entity escapes aren't needed.
+    command.arg(params.text);
 
     command.arg("--title");
     command.arg(params.title);


### PR DESCRIPTION
In #10, it was found that Zenity treats message box text as XML, which meant that some characters needed to be replaced with escapes. 86ed497 escaped these characters for both Zenity and KDialog. However, this caused raw XML entities to show up in messages when using KDialog:
![Message box reading "That\&apos\;s the end!"](https://user-images.githubusercontent.com/8634700/148711900-607a00aa-e37a-4969-acf3-2492d399c12c.png)

To fix this, this patch simply avoids escaping when using KDialog:
![Message box reading "That's the end!"](https://user-images.githubusercontent.com/8634700/148711977-e9f8f5c1-65fc-4531-9890-efd61db87ad4.png)