### PR TITLE
fix typo in error message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub enum Error {
     #[error("failed to parse the string returned from implementation")]
     UnexpectedOutput(&'static str),
 
-    #[error("cannot find any dialog implementation (kdialog/zanity)")]
+    #[error("cannot find any dialog implementation (kdialog/zenity)")]
     NoImplementation,
 
     #[error("the implementation reports error")]


### PR DESCRIPTION
I recently had this error and had to lookup available packages to install, and found that it should be spelled "zenity"