### PR TITLE
Fixed a build issue on Linux.

### DIFF
--- a/src/dialog_impl/gnu/message.rs
+++ b/src/dialog_impl/gnu/message.rs
@@ -59,7 +59,8 @@ fn convert_qt_text_document(text: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\n', "<br>")
-        .replace(&[' ', '\t'], "&nbsp;")
+        .replace(' ', "&nbsp")
+        .replace('\t', "&nbsp;")
 }
 
 struct Params<'a> {


### PR DESCRIPTION
I've hit the following issue while trying to compile my program on Linux.

<details>
<summary>Issue</summary>

```
error[E0277]: expected a `Fn<(char,)>` closure, found `[char; 2]`
  --> src/dialog_impl/gnu/message.rs:62:18
   |
62 |         .replace(&[' ', '\t'], "&nbsp;")
   |          ------- ^^^^^^^^^^^^ expected an `Fn<(char,)>` closure, found `[char; 2]`
   |          |
   |          required by a bound introduced by this call
   |
   = help: the trait `Fn<(char,)>` is not implemented for `[char; 2]`
   = note: required because of the requirements on the impl of `FnOnce<(char,)>` for `&[char; 2]`
   = note: required because of the requirements on the impl of `Pattern<'_>` for `&[char; 2]`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `native-dialog` due to previous error
```
</details>

It was due to the `String::replace(char, &str)` receiving the `[char;2]` instead.
I've replaced it with two `replace` calls instead.